### PR TITLE
Add UnstoredBufferLength to IOutputStream

### DIFF
--- a/Windows.Storage.Streams/DataWriter.cs
+++ b/Windows.Storage.Streams/DataWriter.cs
@@ -61,7 +61,7 @@ namespace Windows.Storage.Streams
             get
             {
                 // need to use reflection to reach the field value
-                return (uint)_stream.GetType().GetField("_unstoredBufferLength", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(_stream);
+                return _stream.UnstoredBufferLength;
             }
         }
 

--- a/Windows.Storage.Streams/IOutputStream.cs
+++ b/Windows.Storage.Streams/IOutputStream.cs
@@ -11,6 +11,12 @@ namespace Windows.Storage.Streams
     public interface IOutputStream
     {
         /// <summary>
+        /// Gets the size of the buffer that has not been used.
+        /// </summary>
+        /// <value>The available buffer length, in bytes.</value>
+        uint UnstoredBufferLength { get; set; }
+
+        /// <summary>
         /// Flushes data in a sequential stream.
         /// </summary>
         /// <returns>The stream flush operation.</returns>

--- a/Windows.Storage.Streams/InMemoryRandomAccessStream.cs
+++ b/Windows.Storage.Streams/InMemoryRandomAccessStream.cs
@@ -32,6 +32,9 @@ namespace Windows.Storage.Streams
 
         private const uint MemStreamMaxLength = 0xFFFF;
 
+        /// <inheritdoc/>
+        public uint UnstoredBufferLength { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
         /// <summary>
         /// Gets a value that indicates whether the stream can be read from.
         /// </summary>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.10.1-preview.{height}",
+  "version": "1.11.0-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- Update InMemoryRandomAccessStream accordingly.
- Replace getter in UnstoredBufferLength so that reflection is not required.
- Bump version to 1.11.0-preview.

## Motivation and Context
- Need to access this property without using reflection (not available in targets using the mscorlib without support for reflection).

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
